### PR TITLE
修复华为手机无障碍辅助双击失效的BUG

### DIFF
--- a/cpymo-backends/android/app/src/main/java/xyz/xydm/cpymo/gesture/GestureDetector.java
+++ b/cpymo-backends/android/app/src/main/java/xyz/xydm/cpymo/gesture/GestureDetector.java
@@ -209,12 +209,10 @@ public class GestureDetector {
             }
             case MotionEvent.ACTION_UP: {
                 SlideDetector.Direction[] directions = detector.getDirections();
-                if (directions.length == 1) {
-                    gotoState(State.Initial);
-                    mListener.onSlide(event, directions[0]);
-                    return true;
-                }
-                return false;
+                if (directions.length != 1) return false;
+                gotoState(State.Initial);
+                mListener.onSlide(event, directions[0]);
+                return true;
             }
         }
         return false;
@@ -231,8 +229,13 @@ public class GestureDetector {
     }
 
     private boolean dispatchOneDoubleDown(@NonNull MotionEvent event) {
+        int index = event.getActionIndex();
+        int pointerId = event.getPointerId(index);
+
         switch (event.getActionMasked()) {
             case MotionEvent.ACTION_MOVE: {
+                SlideDetector detector = getPointerDetector(pointerId);
+                if (detector.ignoreTinyMove(event)) return true;
                 cancelDelay1();
                 gotoState(State.OneMove);
                 return true;
@@ -342,8 +345,7 @@ public class GestureDetector {
         switch (event.getActionMasked()) {
             case MotionEvent.ACTION_MOVE: {
                 SlideDetector detector = getPointerDetector(pointerId);
-                if (detector.ignoreTinyMove(event))
-                    return true;
+                if (detector.ignoreTinyMove(event)) return true;
                 cancelDelay4();
                 return false;
             }
@@ -406,10 +408,6 @@ public class GestureDetector {
                 gotoState(State.TwoDoubleDownUpOne);
                 sendDelay4(event);
                 return true;
-            }
-            case MotionEvent.ACTION_UP: {
-//                throw new RuntimeException("不应该出现这个事件");
-                return false;
             }
         }
         return false;

--- a/cpymo-backends/android/app/src/main/java/xyz/xydm/cpymo/gesture/OnGestureListener.java
+++ b/cpymo-backends/android/app/src/main/java/xyz/xydm/cpymo/gesture/OnGestureListener.java
@@ -17,7 +17,7 @@ public interface OnGestureListener {
 //    void onLongPressAfterTap(MotionEvent e);
 //    void onScanAfterTap(MotionEvent e);
 //    void onFlingAfterTap(MotionEvent e);
-    void onDoubleTap(MotionEvent event);
+    void onDoubleTap(MotionEvent event);    //FIXME 华为手机双击失效
 //    void onTwoTap(MotionEvent event);
     void onTwoDoubleTap(MotionEvent event);
 


### PR DESCRIPTION
# 问题描述
经测试，多部华为手机都存在无障碍模式下双击失效的问题，但是使用读屏软件的模拟双击功能则可以正常操作，原因待查明