### PR TITLE
修复Android无障碍触摸Bug，并更新版本号

### DIFF
--- a/cpymo-backends/android/app/build.gradle
+++ b/cpymo-backends/android/app/build.gradle
@@ -23,8 +23,8 @@ android {
         applicationId "xyz.xydm.cpymo"
         minSdk 18
         targetSdk 32
-        versionCode 2
-        versionName "1.1.1"
+        versionCode 3
+        versionName "1.1.3"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         externalNativeBuild {

--- a/cpymo-backends/android/app/src/main/java/org/libsdl/app/SDLActivity.java
+++ b/cpymo-backends/android/app/src/main/java/org/libsdl/app/SDLActivity.java
@@ -2182,14 +2182,7 @@ class SDLSurface extends SurfaceView implements SurfaceHolder.Callback,
 
     @Override
     public void onScan(MotionEvent event, float x, float y) {
-        int touchDevId = event.getDeviceId();
-        int index = event.getActionIndex();
-        int pointerId = event.getPointerId(index);
-        x /= mWidth;
-        y /= mHeight;
-        float p = event.getPressure(index);
-        if (p > 1.0f) p = 1.0f;
-        SDLActivity.onNativeTouch(touchDevId, pointerId, MotionEvent.ACTION_MOVE, x, y, p);
+        SDLActivity.onNativeMouse(0, MotionEvent.ACTION_HOVER_MOVE, x, y, false);
     }
 
     @Override

--- a/cpymo-backends/ios/CMakeLists.txt
+++ b/cpymo-backends/ios/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.18.1)
 project(cpymo
-        VERSION 1.0.0
+        VERSION 1.1.3
         LANGUAGES C OBJC
         )
 


### PR DESCRIPTION
## 1. 修复Android无障碍触摸Bug

### Bug现象
> 按住屏幕并滑动后，会概率性出现无法双击回车，或长按返回的现象

### Bug原因
> `SDLActivity.onNativeTouch`会被SDL解析为一次触摸输入， 虽然之前的代码仅仅发送了ACTION_MOVE，但是触摸输入的逻辑就是按下->移动->松开，所以SDL可能会擅自发送按下的事件，于是就造成cpymo收到了按下和移动的事件，但并没有收到松开事件，所以鼠标一直按下的情况下，回车键esc键自然是无法正常工作了

### 修复方法
> 使用`SDLActivity.onNativeMouse`即可发送纯鼠标事件（这个API本就是为了给Android设备外接鼠标而设计的）

### 注意事项
> 由于`onNativeMouse`缺乏详细的文档，我只是照着已有的代码写法来写的，而对于最后一个参数`relative`的含义并不太了解，所以这里有待更多的测试和验证

## 2. 更新Android和iOS的版本号为1.1.3
